### PR TITLE
Invertir orden de test

### DIFF
--- a/Capítulo 02/ejercicio01/test/css.test.js
+++ b/Capítulo 02/ejercicio01/test/css.test.js
@@ -35,8 +35,8 @@ describe('Test unitarios para la ruta `/`', function() {
         .then((response) => {
 
           chai.expect(response.text).to.have.rule('#section-one')
-            .and.decl('color','white')
             .and.decl('background-color', 'var(--color-1)')
+            .and.decl('color','white')
 
           
         })


### PR DESCRIPTION
Consigna pide `background-color` primero, mientras que en el test está al revés.